### PR TITLE
Handling changes in cURL 7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ try {
 
 ```
 
-Note about cURL >= 7.10
+Note about cURL SSL verify peer option
 -----------------------
-Since 7.10 version cURL has CURLOPT_SSL_VERIFYPEER option enabled by default. To handle this you need to [download](http://curl.haxx.se/docs/caextract.html) root certificates and add them somewhere into your project directory. Then construct Sender object like this:
+Library has turned off CURLOPT_SSL_VERIFYPEER by default, but you can enable it by passing third parameter into constructor of Sender class.
+
+You need to [download](http://curl.haxx.se/docs/caextract.html) root certificates and add them somewhere into your project directory. Then construct Sender object like this:
 
 ```php
 

--- a/library/CodeMonkeysRu/GCM/Sender.php
+++ b/library/CodeMonkeysRu/GCM/Sender.php
@@ -101,6 +101,8 @@ class Sender
         if ($this->caInfoPath !== false) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
             curl_setopt($ch, CURLOPT_CAINFO, $this->caInfoPath);
+        } else {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         }
 
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);


### PR DESCRIPTION
In cURL 7.10 and above CURLOPT_SSL_VERIFYPEER is true by default. It
makes library not working without certificates (you can get them here:
http://curl.haxx.se/docs/caextract.html).
